### PR TITLE
FR - 22480 rebac listings backend

### DIFF
--- a/src/spicedb/spicedb-entitlements.client.lookup-resources.spec.ts
+++ b/src/spicedb/spicedb-entitlements.client.lookup-resources.spec.ts
@@ -4,6 +4,7 @@ import { LoggingClient } from '../logging';
 import { ClientConfiguration } from '../client-configuration';
 import { v1 } from '@authzed/authzed-node';
 import { LookupResourcesRequest } from '../types';
+import { encodeObjectId } from './spicedb-queries/base64.utils';
 
 describe('SpiceDBEntitlementsClient.lookupResources', () => {
 	let mockSpiceClient: MockProxy<v1.ZedPromiseClientInterface>;
@@ -31,18 +32,19 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 	});
 
 	describe('successful lookups', () => {
-		it('should return resources with correct structure', async () => {
+		it('should return resources with correct structure (decoded from base64)', async () => {
+			// SpiceDB returns base64-encoded IDs
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
 				},
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-2',
+					resourceObjectId: encodeObjectId('resource-2'),
 					permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
@@ -53,6 +55,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const result = await client.lookupResources(defaultRequest);
 
 			expect(result.resources).toHaveLength(2);
+			// Response should contain decoded IDs
 			expect(result.resources[0]).toEqual({
 				resourceType: 'document',
 				resourceId: 'resource-1',
@@ -101,7 +104,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			);
 		});
 
-		it('should build correct SpiceDB request', async () => {
+		it('should build correct SpiceDB request with base64-encoded subjectId', async () => {
 			mockSpiceClient.lookupResources.mockResolvedValue([]);
 
 			await client.lookupResources(defaultRequest);
@@ -113,7 +116,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 					subject: expect.objectContaining({
 						object: expect.objectContaining({
 							objectType: 'user',
-							objectId: 'user-123'
+							objectId: encodeObjectId('user-123') // Request should encode the ID
 						}),
 						optionalRelation: ''
 					})
@@ -127,7 +130,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			// Create 50 mock results (the default limit) with a cursor
 			const mockResults: v1.LookupResourcesResponse[] = Array.from({ length: 50 }, (_, i) => ({
 				lookedUpAt: undefined,
-				resourceObjectId: `resource-${i + 1}`,
+				resourceObjectId: encodeObjectId(`resource-${i + 1}`),
 				permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 				partialCaveatInfo: undefined,
 				afterResultCursor: i === 49 ? { token: 'next-page-token' } : undefined
@@ -144,7 +147,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: { token: 'next-page-token' }
@@ -162,7 +165,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined // No cursor
@@ -208,7 +211,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
@@ -225,7 +228,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
@@ -242,7 +245,7 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'resource-1',
+					resourceObjectId: encodeObjectId('resource-1'),
 					permissionship: v1.LookupPermissionship.UNSPECIFIED,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
@@ -270,21 +273,21 @@ describe('SpiceDBEntitlementsClient.lookupResources', () => {
 			const mockResults: v1.LookupResourcesResponse[] = [
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'first',
+					resourceObjectId: encodeObjectId('first'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
 				},
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'second',
+					resourceObjectId: encodeObjectId('second'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined
 				},
 				{
 					lookedUpAt: undefined,
-					resourceObjectId: 'third',
+					resourceObjectId: encodeObjectId('third'),
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					afterResultCursor: undefined

--- a/src/spicedb/spicedb-entitlements.client.lookup-subjects.spec.ts
+++ b/src/spicedb/spicedb-entitlements.client.lookup-subjects.spec.ts
@@ -4,6 +4,7 @@ import { LoggingClient } from '../logging';
 import { ClientConfiguration } from '../client-configuration';
 import { v1 } from '@authzed/authzed-node';
 import { LookupSubjectsRequest } from '../types';
+import { encodeObjectId } from './spicedb-queries/base64.utils';
 
 describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 	let mockSpiceClient: MockProxy<v1.ZedPromiseClientInterface>;
@@ -31,16 +32,17 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 	});
 
 	describe('successful lookups', () => {
-		it('should return subjects with correct structure', async () => {
+		it('should return subjects with correct structure (decoded from base64)', async () => {
+			// SpiceDB returns base64-encoded IDs
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-1',
+					subjectObjectId: encodeObjectId('user-1'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'user-1',
+						subjectObjectId: encodeObjectId('user-1'),
 						permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -49,12 +51,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 				},
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-2',
+					subjectObjectId: encodeObjectId('user-2'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'user-2',
+						subjectObjectId: encodeObjectId('user-2'),
 						permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -67,6 +69,7 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const result = await client.lookupSubjects(defaultRequest);
 
 			expect(result.subjects).toHaveLength(2);
+			// Response should contain decoded IDs
 			expect(result.subjects[0]).toEqual({
 				subjectType: 'user',
 				subjectId: 'user-1',
@@ -89,7 +92,7 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			expect(result.totalReturned).toBe(0);
 		});
 
-		it('should build correct SpiceDB request', async () => {
+		it('should build correct SpiceDB request with base64-encoded resourceId', async () => {
 			mockSpiceClient.lookupSubjects.mockResolvedValue([]);
 
 			await client.lookupSubjects(defaultRequest);
@@ -98,7 +101,7 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 				expect.objectContaining({
 					resource: expect.objectContaining({
 						objectType: 'document',
-						objectId: 'doc-123'
+						objectId: encodeObjectId('doc-123') // Request should encode the ID
 					}),
 					permission: 'view',
 					subjectObjectType: 'user'
@@ -112,12 +115,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-1',
+					subjectObjectId: encodeObjectId('user-1'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'user-1',
+						subjectObjectId: encodeObjectId('user-1'),
 						permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -136,12 +139,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-1',
+					subjectObjectId: encodeObjectId('user-1'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'user-1',
+						subjectObjectId: encodeObjectId('user-1'),
 						permissionship: v1.LookupPermissionship.CONDITIONAL_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -160,12 +163,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-1',
+					subjectObjectId: encodeObjectId('user-1'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.UNSPECIFIED,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'user-1',
+						subjectObjectId: encodeObjectId('user-1'),
 						permissionship: v1.LookupPermissionship.UNSPECIFIED,
 						partialCaveatInfo: undefined
 					},
@@ -184,7 +187,7 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'user-1',
+					subjectObjectId: encodeObjectId('user-1'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
@@ -225,12 +228,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 			const mockResults: v1.LookupSubjectsResponse[] = [
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'first',
+					subjectObjectId: encodeObjectId('first'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'first',
+						subjectObjectId: encodeObjectId('first'),
 						permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -239,12 +242,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 				},
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'second',
+					subjectObjectId: encodeObjectId('second'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'second',
+						subjectObjectId: encodeObjectId('second'),
 						permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -253,12 +256,12 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 				},
 				{
 					lookedUpAt: undefined,
-					subjectObjectId: 'third',
+					subjectObjectId: encodeObjectId('third'),
 					excludedSubjectIds: [],
 					permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 					partialCaveatInfo: undefined,
 					subject: {
-						subjectObjectId: 'third',
+						subjectObjectId: encodeObjectId('third'),
 						permissionship: v1.LookupPermissionship.HAS_PERMISSION,
 						partialCaveatInfo: undefined
 					},
@@ -297,4 +300,3 @@ describe('SpiceDBEntitlementsClient.lookupSubjects', () => {
 		});
 	});
 });
-

--- a/src/spicedb/spicedb-queries/base64.utils.spec.ts
+++ b/src/spicedb/spicedb-queries/base64.utils.spec.ts
@@ -1,0 +1,114 @@
+import { encodeObjectId, decodeObjectId } from './base64.utils';
+
+describe('base64.utils', () => {
+	describe('encodeObjectId', () => {
+		it('should encode simple string to base64', () => {
+			const result = encodeObjectId('user-123');
+			expect(result).toBe('dXNlci0xMjM');
+		});
+
+		it('should produce URL-safe base64 (no +, /, or =)', () => {
+			// This string when base64 encoded would normally contain + and /
+			const result = encodeObjectId('test+data/with=special');
+			expect(result).not.toContain('+');
+			expect(result).not.toContain('/');
+			expect(result).not.toContain('=');
+		});
+
+		it('should replace + with -', () => {
+			// Force a scenario that produces + in base64
+			const input = '>>>'; // base64: Pj4+ (contains +)
+			const result = encodeObjectId(input);
+			expect(result).not.toContain('+');
+			expect(result).toContain('-'); // + should be replaced with -
+		});
+
+		it('should replace / with _', () => {
+			// Force a scenario that produces / in base64
+			const input = '???'; // base64: Pz8/ (contains /)
+			const result = encodeObjectId(input);
+			expect(result).not.toContain('/');
+			expect(result).toContain('_'); // / should be replaced with _
+		});
+
+		it('should handle empty string', () => {
+			const result = encodeObjectId('');
+			expect(result).toBe('');
+		});
+
+		it('should handle real customer data IDs', () => {
+			const result = encodeObjectId('user-1-DWdTPCoH');
+			expect(typeof result).toBe('string');
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('decodeObjectId', () => {
+		it('should decode base64 to original string', () => {
+			const encoded = encodeObjectId('user-123');
+			const decoded = decodeObjectId(encoded);
+			expect(decoded).toBe('user-123');
+		});
+
+		it('should handle URL-safe base64 characters', () => {
+			// Encode something that produces + and /
+			const original = '>>>';
+			const encoded = encodeObjectId(original);
+			const decoded = decodeObjectId(encoded);
+			expect(decoded).toBe(original);
+		});
+
+		it('should roundtrip any string correctly', () => {
+			const testCases = [
+				'user-1-DWdTPCoH',
+				'doc-1-aOD3DYIF',
+				'group-15-2FyCyAMR',
+				'sub-100-XcpmSEUD',
+				'test+special/chars=here',
+				'unicode: 日本語'
+			];
+
+			for (const original of testCases) {
+				const encoded = encodeObjectId(original);
+				const decoded = decodeObjectId(encoded);
+				expect(decoded).toBe(original);
+			}
+		});
+
+		it('should handle empty string', () => {
+			const result = decodeObjectId('');
+			expect(result).toBe('');
+		});
+
+		it('should handle base64 strings from SpiceDB export', () => {
+			// Real example from the yaml: Z3JvdXAtMS02MWRrNlRpYw = group-1-61dk6Tic
+			const decoded = decodeObjectId('Z3JvdXAtMS02MWRrNlRpYw');
+			expect(decoded).toBe('group-1-61dk6Tic');
+		});
+
+		it('should handle base64 user IDs from SpiceDB export', () => {
+			// Real example: dXNlci0xLURXZFRQQ29I = user-1-DWdTPCoH
+			const decoded = decodeObjectId('dXNlci0xLURXZFRQQ29I');
+			expect(decoded).toBe('user-1-DWdTPCoH');
+		});
+	});
+
+	describe('encode/decode symmetry', () => {
+		it('should decode what encode produces', () => {
+			const originals = [
+				'simple',
+				'with-dashes',
+				'with_underscores',
+				'with.dots',
+				'CamelCase',
+				'123456',
+				'mixed-123_test.case'
+			];
+
+			for (const original of originals) {
+				expect(decodeObjectId(encodeObjectId(original))).toBe(original);
+			}
+		});
+	});
+});
+

--- a/src/spicedb/spicedb-queries/base64.utils.ts
+++ b/src/spicedb/spicedb-queries/base64.utils.ts
@@ -1,0 +1,9 @@
+export function encodeObjectId(objectId: string): string {
+	return Buffer.from(objectId).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+export function decodeObjectId(encodedId: string): string {
+	const base64 = encodedId.replace(/-/g, '+').replace(/_/g, '/');
+	const paddedBase64 = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+	return Buffer.from(paddedBase64, 'base64').toString('utf-8');
+}

--- a/src/spicedb/spicedb-queries/entitlements-spicedb.query.ts
+++ b/src/spicedb/spicedb-queries/entitlements-spicedb.query.ts
@@ -8,6 +8,7 @@ import {
 } from '../../types';
 import { SpiceDBResponse } from '../../types/spicedb.dto';
 import { SpiceDBEntities } from '../../types/spicedb-consts';
+import { encodeObjectId } from './base64.utils';
 
 export interface HashOptions {
 	hashResourceId: boolean;
@@ -65,13 +66,13 @@ export abstract class EntitlementsSpiceDBQuery {
 		return {
 			resource: {
 				objectType: resourceObjectType,
-				objectId: hashOptions.hashResourceId ? this.normalizeObjectId(resourceObjectId) : resourceObjectId
+				objectId: hashOptions.hashResourceId ? encodeObjectId(resourceObjectId) : resourceObjectId
 			},
 			permission: 'access',
 			subject: {
 				object: {
 					objectType: subjectObjectType,
-					objectId: hashOptions.hashSubjectId ? this.normalizeObjectId(subjectObjectId) : subjectObjectId
+					objectId: hashOptions.hashSubjectId ? encodeObjectId(subjectObjectId) : subjectObjectId
 				},
 				optionalRelation: ''
 			},
@@ -134,11 +135,6 @@ export abstract class EntitlementsSpiceDBQuery {
 			result: { result } as EntitlementsResult
 		} as SpiceDBResponse<EntitlementsResult>;
 	}
-
-	protected normalizeObjectId(objectId: string): string {
-		return Buffer.from(objectId).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-	}
-
 	protected async isPermissionLinkedToFeatures(
 		requestContext: PermissionsEntitlementsContext,
 		hashResourceId: boolean = true
@@ -147,9 +143,7 @@ export abstract class EntitlementsSpiceDBQuery {
 			permission: 'parent',
 			resource: {
 				objectType: SpiceDBEntities.Permission,
-				objectId: hashResourceId
-					? this.normalizeObjectId(requestContext.permissionKey)
-					: requestContext.permissionKey
+				objectId: hashResourceId ? encodeObjectId(requestContext.permissionKey) : requestContext.permissionKey
 			},
 			subjectObjectType: SpiceDBEntities.Feature
 		});

--- a/src/spicedb/spicedb-queries/fga-spicedb.query.ts
+++ b/src/spicedb/spicedb-queries/fga-spicedb.query.ts
@@ -2,6 +2,7 @@ import { EntitlementsSpiceDBQuery } from './entitlements-spicedb.query';
 import { EntitlementsDynamicQuery, EntitlementsResult, FGASubjectContext, RequestContextType } from '../../types';
 import { SpiceDBResponse } from '../../types/spicedb.dto';
 import { v1 } from '@authzed/authzed-node';
+import { encodeObjectId } from './base64.utils';
 
 export class FgaSpiceDBQuery extends EntitlementsSpiceDBQuery {
 	constructor(protected readonly client: v1.ZedPromiseClientInterface) {
@@ -17,13 +18,13 @@ export class FgaSpiceDBQuery extends EntitlementsSpiceDBQuery {
 			subject: {
 				object: {
 					objectType: context.entityType,
-					objectId: this.normalizeObjectId(context.key)
+					objectId: encodeObjectId(context.key)
 				},
 				optionalRelation: ''
 			},
 			resource: {
 				objectType: requestContext.entityType,
-				objectId: this.normalizeObjectId(requestContext.key)
+				objectId: encodeObjectId(requestContext.key)
 			},
 			permission: requestContext.action
 		});

--- a/src/spicedb/spicedb-queries/lookup-request.builder.ts
+++ b/src/spicedb/spicedb-queries/lookup-request.builder.ts
@@ -1,5 +1,6 @@
 import { v1 } from '@authzed/authzed-node';
 import { LookupResourcesRequest, LookupSubjectsRequest } from '../../types/lookup.types';
+import { encodeObjectId } from './base64.utils';
 
 export function buildLookupResourcesRequest(params: LookupResourcesRequest): v1.LookupResourcesRequest {
 	const { subjectType, subjectId, resourceType, permission, limit, cursor } = params;
@@ -10,7 +11,7 @@ export function buildLookupResourcesRequest(params: LookupResourcesRequest): v1.
 		subject: {
 			object: {
 				objectType: subjectType,
-				objectId: subjectId
+				objectId: encodeObjectId(subjectId)
 			},
 			optionalRelation: ''
 		},
@@ -25,7 +26,7 @@ export function buildLookupSubjectsRequest(params: LookupSubjectsRequest): v1.Lo
 	return v1.LookupSubjectsRequest.create({
 		resource: {
 			objectType: resourceType,
-			objectId: resourceId
+			objectId: encodeObjectId(resourceId)
 		},
 		permission: permission,
 		subjectObjectType: subjectType

--- a/src/spicedb/spicedb-queries/lookup-response.mapper.ts
+++ b/src/spicedb/spicedb-queries/lookup-response.mapper.ts
@@ -7,6 +7,7 @@ import {
 	Permissionship
 } from '../../types';
 import { permissionshipMap } from '../lookup.constants';
+import { decodeObjectId } from './base64.utils';
 
 export function mapLookupResourcesResponse(
 	results: v1.LookupResourcesResponse[],
@@ -15,7 +16,7 @@ export function mapLookupResourcesResponse(
 ): LookupResourcesResponse {
 	const resources: LookupResourceItem[] = results.map((result) => ({
 		resourceType,
-		resourceId: result.resourceObjectId,
+		resourceId: decodeObjectId(result.resourceObjectId),
 		permissionship: permissionshipMap.get(result.permissionship)
 	}));
 
@@ -35,7 +36,7 @@ export function mapLookupSubjectsResponse(
 ): LookupSubjectsResponse {
 	const subjects: LookupSubjectItem[] = results.map((result) => ({
 		subjectType,
-		subjectId: result.subject?.subjectObjectId ?? '',
+		subjectId: decodeObjectId(result.subject?.subjectObjectId ?? ''),
 		permissionship: result.subject ? permissionshipMap.get(result.subject.permissionship) : undefined
 	}));
 

--- a/src/spicedb/spicedb-queries/route-spicedb.query.ts
+++ b/src/spicedb/spicedb-queries/route-spicedb.query.ts
@@ -4,6 +4,7 @@ import { SpiceDBResponse } from '../../types/spicedb.dto';
 import { v1 } from '@authzed/authzed-node';
 import { LRUCache } from 'lru-cache';
 import { SpiceDBEntities } from '../../types/spicedb-consts';
+import { encodeObjectId } from './base64.utils';
 
 export class RouteSpiceDBQuery extends EntitlementsSpiceDBQuery {
 	private readonly cache: LRUCache<string, any>;
@@ -98,7 +99,7 @@ export class RouteSpiceDBQuery extends EntitlementsSpiceDBQuery {
 		firstRule = objects[0];
 
 		for (const rule of objects) {
-			const hashedPermissions = context.permissions?.map((permission) => this.normalizeObjectId(permission));
+			const hashedPermissions = context.permissions?.map((permission) => encodeObjectId(permission));
 			if (rule.relation.includes('required_permission')) {
 				if (!this.hasPermission(rule.subjectId, hashedPermissions)) {
 					return this.createResult(false, isMonitoringEnabled);


### PR DESCRIPTION
…ource and decode response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds URL-safe base64 handling for SpiceDB object IDs to standardize API interactions.
> 
> - New `base64.utils` with `encodeObjectId`/`decodeObjectId`
> - Encode IDs in `lookup-request.builder` and query classes (`entitlements-spicedb.query`, `fga-spicedb.query`, `route-spicedb.query`)
> - Decode IDs in `lookup-response.mapper` so consumers receive plain IDs
> - Replace internal normalization with shared utils; adjust permissions hashing in route rules
> - Update/expand unit tests for requests, response mapping, pagination behavior, and encode/decode symmetry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71944835cc74ec41286bee46b0eedff61b67c3b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->