### PR TITLE
FR-23027 - fix client security settings

### DIFF
--- a/src/spicedb/spicedb-entitlements.client.ts
+++ b/src/spicedb/spicedb-entitlements.client.ts
@@ -34,7 +34,7 @@ export class SpiceDBEntitlementsClient {
 		this.spiceClient = v1.NewClient(
 			this.configuration.spiceDBToken,
 			this.configuration.spiceDBEndpoint,
-			v1.ClientSecurity.INSECURE_LOCALHOST_ALLOWED
+			v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS
 		).promises;
 
 		this.spiceDBQueryClient = new SpiceDBQueryClient(this.spiceClient);

--- a/src/spicedb/spicedb-entitlements.client.ts
+++ b/src/spicedb/spicedb-entitlements.client.ts
@@ -40,7 +40,7 @@ export class SpiceDBEntitlementsClient {
 
 			this.spiceDBQueryClient = new SpiceDBQueryClient(this.spiceClient);
 		} catch (initError) {
-			this.loggingClient.error({
+			void this.loggingClient.error({
 				action: 'SpiceDBClient:init:error',
 				endpoint: this.configuration.spiceDBEndpoint,
 				error: initError,
@@ -65,16 +65,7 @@ export class SpiceDBEntitlementsClient {
 			}
 			return res.result;
 		} catch (err) {
-			await this.loggingClient.error({
-				action: 'SpiceDBClient:isEntitledTo:error',
-				endpoint: this.configuration.spiceDBEndpoint,
-				subjectContext,
-				requestContext,
-				error: err,
-				errorMessage: err instanceof Error ? err.message : String(err),
-				errorStack: err instanceof Error ? err.stack : undefined
-			});
-
+			await this.loggingClient.error(err);
 			return this.constructFallbackResult(requestContext);
 		}
 	}
@@ -98,14 +89,7 @@ export class SpiceDBEntitlementsClient {
 			}
 			return mapLookupResourcesResponse(results, req.resourceType, limit);
 		} catch (err) {
-			await this.loggingClient.error({
-				action: 'SpiceDBClient:lookupResources:error',
-				endpoint: this.configuration.spiceDBEndpoint,
-				request: req,
-				error: err,
-				errorMessage: err instanceof Error ? err.message : String(err),
-				errorStack: err instanceof Error ? err.stack : undefined
-			});
+			await this.loggingClient.error(err);
 			throw err;
 		}
 	}
@@ -126,14 +110,7 @@ export class SpiceDBEntitlementsClient {
 			}
 			return mapLookupSubjectsResponse(results, req.subjectType);
 		} catch (err) {
-			await this.loggingClient.error({
-				action: 'SpiceDBClient:lookupSubjects:error',
-				endpoint: this.configuration.spiceDBEndpoint,
-				request: req,
-				error: err,
-				errorMessage: err instanceof Error ? err.message : String(err),
-				errorStack: err instanceof Error ? err.stack : undefined
-			});
+			await this.loggingClient.error(err);
 			throw err;
 		}
 	}

--- a/src/spicedb/spicedb-entitlements.client.ts
+++ b/src/spicedb/spicedb-entitlements.client.ts
@@ -64,21 +64,18 @@ export class SpiceDBEntitlementsClient {
 		subjectContext: SubjectContext,
 		requestContext: RequestContext
 	): Promise<EntitlementsResult> {
-		const startTime = Date.now();
-
 		// Log the incoming request
 		this.loggingClient.logRequest(
 			{ action: 'SpiceDBClient:isEntitledTo:start', subjectContext, requestContext },
-			{ endpoint: this.configuration.spiceDBEndpoint, timestamp: new Date().toISOString() }
+			{ endpoint: this.configuration.spiceDBEndpoint }
 		);
 
 		try {
 			const res = await this.spiceDBQueryClient.spiceDBQuery(subjectContext, requestContext);
-			const duration = Date.now() - startTime;
 
 			this.loggingClient.logRequest(
 				{ action: 'SpiceDBClient:isEntitledTo:success', subjectContext, requestContext },
-				{ result: res.result, duration: `${duration}ms` }
+				{ result: res.result }
 			);
 
 			if (res.result.monitoring || this.logResults) {
@@ -90,14 +87,11 @@ export class SpiceDBEntitlementsClient {
 			}
 			return res.result;
 		} catch (err) {
-			const duration = Date.now() - startTime;
-
 			await this.loggingClient.error({
 				action: 'SpiceDBClient:isEntitledTo:error',
 				endpoint: this.configuration.spiceDBEndpoint,
 				subjectContext,
 				requestContext,
-				duration: `${duration}ms`,
 				error: err,
 				errorMessage: err instanceof Error ? err.message : String(err),
 				errorStack: err instanceof Error ? err.stack : undefined
@@ -108,11 +102,9 @@ export class SpiceDBEntitlementsClient {
 	}
 
 	public async lookupResources(req: LookupResourcesRequest): Promise<LookupResourcesResponse> {
-		const startTime = Date.now();
-
 		this.loggingClient.logRequest(
 			{ action: 'SpiceDBClient:lookupResources:start', request: req },
-			{ endpoint: this.configuration.spiceDBEndpoint, timestamp: new Date().toISOString() }
+			{ endpoint: this.configuration.spiceDBEndpoint }
 		);
 
 		try {
@@ -127,11 +119,10 @@ export class SpiceDBEntitlementsClient {
 			});
 
 			const results = await this.spiceClient.lookupResources(request);
-			const duration = Date.now() - startTime;
 
 			this.loggingClient.logRequest(
 				{ action: 'SpiceDBClient:lookupResources:success', request: req },
-				{ resultsCount: results.length, duration: `${duration}ms` }
+				{ resultsCount: results.length }
 			);
 
 			if (this.logResults) {
@@ -139,13 +130,10 @@ export class SpiceDBEntitlementsClient {
 			}
 			return mapLookupResourcesResponse(results, req.resourceType, limit);
 		} catch (err) {
-			const duration = Date.now() - startTime;
-
 			await this.loggingClient.error({
 				action: 'SpiceDBClient:lookupResources:error',
 				endpoint: this.configuration.spiceDBEndpoint,
 				request: req,
-				duration: `${duration}ms`,
 				error: err,
 				errorMessage: err instanceof Error ? err.message : String(err),
 				errorStack: err instanceof Error ? err.stack : undefined
@@ -155,11 +143,9 @@ export class SpiceDBEntitlementsClient {
 	}
 
 	public async lookupSubjects(req: LookupSubjectsRequest): Promise<LookupSubjectsResponse> {
-		const startTime = Date.now();
-
 		this.loggingClient.logRequest(
 			{ action: 'SpiceDBClient:lookupSubjects:start', request: req },
-			{ endpoint: this.configuration.spiceDBEndpoint, timestamp: new Date().toISOString() }
+			{ endpoint: this.configuration.spiceDBEndpoint }
 		);
 
 		try {
@@ -171,11 +157,10 @@ export class SpiceDBEntitlementsClient {
 			});
 
 			const results = await this.spiceClient.lookupSubjects(request);
-			const duration = Date.now() - startTime;
 
 			this.loggingClient.logRequest(
 				{ action: 'SpiceDBClient:lookupSubjects:success', request: req },
-				{ resultsCount: results.length, duration: `${duration}ms` }
+				{ resultsCount: results.length }
 			);
 
 			if (this.logResults) {
@@ -183,13 +168,10 @@ export class SpiceDBEntitlementsClient {
 			}
 			return mapLookupSubjectsResponse(results, req.subjectType);
 		} catch (err) {
-			const duration = Date.now() - startTime;
-
 			await this.loggingClient.error({
 				action: 'SpiceDBClient:lookupSubjects:error',
 				endpoint: this.configuration.spiceDBEndpoint,
 				request: req,
-				duration: `${duration}ms`,
 				error: err,
 				errorMessage: err instanceof Error ? err.message : String(err),
 				errorStack: err instanceof Error ? err.stack : undefined

--- a/src/spicedb/spicedb-entitlements.client.ts
+++ b/src/spicedb/spicedb-entitlements.client.ts
@@ -56,7 +56,6 @@ export class SpiceDBEntitlementsClient {
 	): Promise<EntitlementsResult> {
 		try {
 			const res = await this.spiceDBQueryClient.spiceDBQuery(subjectContext, requestContext);
-
 			if (res.result.monitoring || this.logResults) {
 				await this.loggingClient.log(subjectContext, requestContext, res);
 			}
@@ -93,6 +92,10 @@ export class SpiceDBEntitlementsClient {
 			});
 
 			const results = await this.spiceClient.lookupResources(request);
+
+			if (this.logResults) {
+				await this.loggingClient.logRequest(request, results);
+			}
 			return mapLookupResourcesResponse(results, req.resourceType, limit);
 		} catch (err) {
 			await this.loggingClient.error({
@@ -117,6 +120,10 @@ export class SpiceDBEntitlementsClient {
 			});
 
 			const results = await this.spiceClient.lookupSubjects(request);
+
+			if (this.logResults) {
+				await this.loggingClient.logRequest(request, results);
+			}
 			return mapLookupSubjectsResponse(results, req.subjectType);
 		} catch (err) {
 			await this.loggingClient.error({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `SpiceDBEntitlementsClient` initialization to use `INSECURE_PLAINTEXT_CREDENTIALS` and adds guarded client construction with error logging and rethrow.
> 
> - Switches `v1.NewClient` security from `INSECURE_LOCALHOST_ALLOWED` to `INSECURE_PLAINTEXT_CREDENTIALS`
> - Wraps client and `SpiceDBQueryClient` creation in `try/catch`, logging `SpiceDBClient:init:error` on failure and rethrowing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08eea6f29124a9b67da7b395f4594477e086b51a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->