### PR TITLE
FR-23123 - fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The `at` parameter accepts ISO 8601 format strings:
 -   UTC format: `2025-12-31T23:59:59Z`
 -   Timezone offset: `2025-12-31T23:59:59+02:00`
 
-If not provided, `at` defaults to the current UTC time.
+If `at` not provided, it defaults to the current UTC time.
 
 > **Note:** The `at` parameter is also supported in [Lookup Operations](#lookup-operations) with the same format and behavior.
 
@@ -189,7 +189,7 @@ const response = await e10sClient.lookupTargetEntities({
 	action: 'read',
 	limit: 100, // Optional: limit number of results (default: 50, max: 1000)
 	cursor: undefined, // Optional: pagination cursor
-	at: '2026-01-15T12:00:00.000Z' // Optional: ISO 8601 timestamp for active_at caveat
+	at: '2026-01-15T12:00:00Z' // Optional: ISO 8601 timestamp for active_at caveat
 });
 
 console.log(`Found ${response.totalReturned} Target Entities`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Minor README cleanup for time-based access docs.
> 
> - Standardizes ISO 8601 examples by removing milliseconds (`.000Z` -> `Z`) in `lookupTargetEntities` snippet
> - Clarifies wording for `at` default behavior (defaults to current UTC time)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73fee86b5949bb4d91a8026036ffef467ac04983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->