### PR TITLE
Fr 23296 publish e 10 s client version2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,309 +1,84 @@
-# [3.0.0-alpha.16](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.15...3.0.0-alpha.16) (2026-01-05)
-
-
-### Features
-
-* **spicedb:** add logging for permission check requests and responses ([d4160d5](https://github.com/frontegg/entitlements-client/commit/d4160d5233762746243e6c57da666244be73de89))
-* **spicedb:** add logs for routes ([43d9da6](https://github.com/frontegg/entitlements-client/commit/43d9da63fbb537835a05b83f43a00b770fca1f8b))
-
-# [3.0.0-alpha.15](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.14...3.0.0-alpha.15) (2025-12-31)
-
-
-### Features
-
-* **spicedb:** new version with timebounds ([4c479b6](https://github.com/frontegg/entitlements-client/commit/4c479b65d0361eabadb4c8aab6b3fcdf4af41ed2))
-
-# [3.0.0-alpha.14](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.13...3.0.0-alpha.14) (2025-12-31)
-
-
-### Features
-
-* **spicedb:** release ([4954ac1](https://github.com/frontegg/entitlements-client/commit/4954ac1c769149813fa757a289148677c36c71e6))
-
-# [3.0.0-alpha.13](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.12...3.0.0-alpha.13) (2025-12-30)
-
-
-### Bug Fixes
-
-* **spicedb:** update client security setting to INSECURE_PLAINTEXT_CREDENTIALS ([2b8b6f6](https://github.com/frontegg/entitlements-client/commit/2b8b6f6d2f4353fda066205543c24813fc6efec4))
-
-# [3.0.0-alpha.12](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.11...3.0.0-alpha.12) (2025-12-25)
-
-
-### Features
-
-* **spicedb:** release ([607f49e](https://github.com/frontegg/entitlements-client/commit/607f49e122917fe2cf009da5411f515c304df84a))
-* **spicedb:** test release ([be23ad6](https://github.com/frontegg/entitlements-client/commit/be23ad6ffa860248f3e94b7324a13cf26678ce1d))
-
-# [3.0.0-alpha.12](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.11...3.0.0-alpha.12) (2025-12-25)
-
-
-### Features
-
-* **spicedb:** release ([607f49e](https://github.com/frontegg/entitlements-client/commit/607f49e122917fe2cf009da5411f515c304df84a))
-
-# [3.0.0-alpha.11](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.10...3.0.0-alpha.11) (2025-12-17)
-
-
-### Features
-
-* **spicedb:** replace cache-manager with lru-cache and update cache handling in RouteSpiceDBQuery ([2a6010b](https://github.com/frontegg/entitlements-client/commit/2a6010bedc27f40bbf2790b688cfe8a1d7b47fb1))
-
-# [3.0.0-alpha.10](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.9...3.0.0-alpha.10) (2025-07-22)
-
-
-### Features
-
-* **spicedb:** fixed api permissions ([49f0edf](https://github.com/frontegg/entitlements-client/commit/49f0edfb9bdac71c8bc73fd6711e1aa6d7d304ea))
-
-# [3.0.0-alpha.9](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.8...3.0.0-alpha.9) (2025-07-17)
-
-
-### Features
-
-* **spicedb:** fixed api permissions ([772f2d8](https://github.com/frontegg/entitlements-client/commit/772f2d86f4ca8eeac70cf6def2ff7437523326f3))
-
-# [3.0.0-alpha.8](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.7...3.0.0-alpha.8) (2025-07-17)
-
-
-### Features
-
-* **spicedb:** fixed api permissions ([59edc60](https://github.com/frontegg/entitlements-client/commit/59edc601efd90ab392fd2dd58f859eca0ed77b4b))
-* **spicedb:** fixed api permissions ([ac11d68](https://github.com/frontegg/entitlements-client/commit/ac11d68e06745a61aeba2efc7d9dfc42770da553))
-
-# [3.0.0-alpha.7](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.6...3.0.0-alpha.7) (2025-07-16)
-
-
-### Features
-
-* **spicedb:** fixed api permissions ([a265fe7](https://github.com/frontegg/entitlements-client/commit/a265fe74885243b1a87a15c5206ccec8188e2585))
-
-# [3.0.0-alpha.6](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.5...3.0.0-alpha.6) (2025-07-15)
-
-
-### Features
-
-* **spicedb:** fixed permission check ([334afa6](https://github.com/frontegg/entitlements-client/commit/334afa6367b9184b6bca33c25c7e2cd844bc9a23))
-* **spicedb:** fixed permission test ([efccef6](https://github.com/frontegg/entitlements-client/commit/efccef6187699ed39c4cb0dbb60de3e89bae539d))
-
-# [3.0.0-alpha.5](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.4...3.0.0-alpha.5) (2025-07-15)
-
-
-### Features
-
-* **spicedb:** fixed permissions check ([7304280](https://github.com/frontegg/entitlements-client/commit/7304280a93e50572689ecc02ebaeb610df60b214))
-
-# [3.0.0-alpha.4](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.3...3.0.0-alpha.4) (2025-07-14)
-
-
-### Features
-
-* **spicedb:** fixes ([4921511](https://github.com/frontegg/entitlements-client/commit/4921511e58fc253d16af8095fba7232d26635d2f))
-
-# [3.0.0-alpha.3](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.2...3.0.0-alpha.3) (2025-07-14)
-
-
-### Features
-
-* **spicedb:** fixes ([dab079f](https://github.com/frontegg/entitlements-client/commit/dab079f746e3dc85d6235af0b3e33d3a09cfcafe))
-
-# [3.0.0-alpha.2](https://github.com/frontegg/entitlements-client/compare/3.0.0-alpha.1...3.0.0-alpha.2) (2025-07-10)
-
-
-### Bug Fixes
-
-* **spicedb:** spicedb api fix ([8830d0e](https://github.com/frontegg/entitlements-client/commit/8830d0e11ffd3b58bbf973e5bb33254caa321ad9))
-
-# [3.0.0-alpha.1](https://github.com/frontegg/entitlements-client/compare/2.0.0...3.0.0-alpha.1) (2025-07-10)
-
-
-### Features
-
-* **spicedb:** migrate to spicedb ([3dd3de4](https://github.com/frontegg/entitlements-client/commit/3dd3de423e27f237e0050df8cb8787795c62a3d9))
-
-
-### BREAKING CHANGES
-
-* **spicedb:** Changing engine to spicedb
-
 # [2.0.0](https://github.com/frontegg/entitlements-client/compare/1.2.0...2.0.0) (2025-06-29)
 
-
 ### Bug Fixes
 
-* **composite:** bump version ([d38351f](https://github.com/frontegg/entitlements-client/commit/d38351f5f84dff5e7bcd8d378bdcad46118f8edb))
-* **composite:** bump version ([abc6712](https://github.com/frontegg/entitlements-client/commit/abc671264ed2a914b8c0377b102f785001c5f40e))
-* **composite:** change from partial to nullable ([7098d6b](https://github.com/frontegg/entitlements-client/commit/7098d6b5bf1239038f3ddb3082663c6254e47b75))
-* **composite:** nullable on composite subject context ([6dd1f31](https://github.com/frontegg/entitlements-client/commit/6dd1f317a5b0f8f75afea9dc4f6c4cff31449f4c))
-* **composite:** remove route from composite ([6e09d6b](https://github.com/frontegg/entitlements-client/commit/6e09d6bc7e5bc64f707484b5a60528ab2eae5ad5))
-* **composite:** removed feature from composite ([6d97e3c](https://github.com/frontegg/entitlements-client/commit/6d97e3c5a94500144daa660f83e54b1b90225634))
-* **publish:** republish ([6a6be70](https://github.com/frontegg/entitlements-client/commit/6a6be704908c2d27482cea00f0ddf889ec47ab25))
+-   **composite:** bump version ([d38351f](https://github.com/frontegg/entitlements-client/commit/d38351f5f84dff5e7bcd8d378bdcad46118f8edb))
+-   **composite:** bump version ([abc6712](https://github.com/frontegg/entitlements-client/commit/abc671264ed2a914b8c0377b102f785001c5f40e))
+-   **composite:** change from partial to nullable ([7098d6b](https://github.com/frontegg/entitlements-client/commit/7098d6b5bf1239038f3ddb3082663c6254e47b75))
+-   **composite:** nullable on composite subject context ([6dd1f31](https://github.com/frontegg/entitlements-client/commit/6dd1f317a5b0f8f75afea9dc4f6c4cff31449f4c))
+-   **composite:** remove route from composite ([6e09d6b](https://github.com/frontegg/entitlements-client/commit/6e09d6bc7e5bc64f707484b5a60528ab2eae5ad5))
+-   **composite:** removed feature from composite ([6d97e3c](https://github.com/frontegg/entitlements-client/commit/6d97e3c5a94500144daa660f83e54b1b90225634))
+-   **publish:** republish ([6a6be70](https://github.com/frontegg/entitlements-client/commit/6a6be704908c2d27482cea00f0ddf889ec47ab25))
 
-
-* feat(composite)API response justification type change ([d6a4fdc](https://github.com/frontegg/entitlements-client/commit/d6a4fdcef12d85e3e91d7ea3fe46b78bc76f1b7a))
-
+-   feat(composite)API response justification type change ([d6a4fdc](https://github.com/frontegg/entitlements-client/commit/d6a4fdcef12d85e3e91d7ea3fe46b78bc76f1b7a))
 
 ### Features
 
-* **fga:** add fga policy query ([7ff9dd5](https://github.com/frontegg/entitlements-client/commit/7ff9dd56891a2b727f07d3b69857c01ea9377e14))
-* **log:** add subject and request context to logger ([f65e60a](https://github.com/frontegg/entitlements-client/commit/f65e60ad76b90580654e806326ba28fb4b67bf16))
-
-
-### BREAKING CHANGES
-
-* The justification type has been changed from enum to string in order to support multiple justification types
-
-# [2.0.0-alpha.6](https://github.com/frontegg/entitlements-client/compare/2.0.0-alpha.5...2.0.0-alpha.6) (2025-06-29)
-
-
-### Bug Fixes
-
-* **composite:** removed feature from composite ([6d97e3c](https://github.com/frontegg/entitlements-client/commit/6d97e3c5a94500144daa660f83e54b1b90225634))
-
-# [2.0.0-alpha.5](https://github.com/frontegg/entitlements-client/compare/2.0.0-alpha.4...2.0.0-alpha.5) (2025-06-29)
-
-
-### Bug Fixes
-
-* **composite:** remove route from composite ([6e09d6b](https://github.com/frontegg/entitlements-client/commit/6e09d6bc7e5bc64f707484b5a60528ab2eae5ad5))
-
-# [2.0.0-alpha.4](https://github.com/frontegg/entitlements-client/compare/2.0.0-alpha.3...2.0.0-alpha.4) (2025-06-26)
-
-
-### Bug Fixes
-
-* **composite:** nullable on composite subject context ([6dd1f31](https://github.com/frontegg/entitlements-client/commit/6dd1f317a5b0f8f75afea9dc4f6c4cff31449f4c))
-
-# [2.0.0-alpha.3](https://github.com/frontegg/entitlements-client/compare/2.0.0-alpha.2...2.0.0-alpha.3) (2025-06-26)
-
-
-### Bug Fixes
-
-* **composite:** change from partial to nullable ([7098d6b](https://github.com/frontegg/entitlements-client/commit/7098d6b5bf1239038f3ddb3082663c6254e47b75))
-
-# [2.0.0-alpha.2](https://github.com/frontegg/entitlements-client/compare/2.0.0-alpha.1...2.0.0-alpha.2) (2025-06-26)
-
-
-### Bug Fixes
-
-* **composite:** bump version ([d38351f](https://github.com/frontegg/entitlements-client/commit/d38351f5f84dff5e7bcd8d378bdcad46118f8edb))
-
-# [2.0.0-alpha.1](https://github.com/frontegg/entitlements-client/compare/1.3.0-alpha.3...2.0.0-alpha.1) (2025-06-25)
-
-
-* feat(composite)API response justification type change ([d6a4fdc](https://github.com/frontegg/entitlements-client/commit/d6a4fdcef12d85e3e91d7ea3fe46b78bc76f1b7a))
-
+-   **fga:** add fga policy query ([7ff9dd5](https://github.com/frontegg/entitlements-client/commit/7ff9dd56891a2b727f07d3b69857c01ea9377e14))
+-   **log:** add subject and request context to logger ([f65e60a](https://github.com/frontegg/entitlements-client/commit/f65e60ad76b90580654e806326ba28fb4b67bf16))
 
 ### BREAKING CHANGES
 
-* The justification type has been changed from enum to string in order to support multiple justification types
-
-# [1.3.0-alpha.3](https://github.com/frontegg/entitlements-client/compare/1.3.0-alpha.2...1.3.0-alpha.3) (2025-06-24)
-
-
-### Bug Fixes
-
-* **composite:** bump version ([abc6712](https://github.com/frontegg/entitlements-client/commit/abc671264ed2a914b8c0377b102f785001c5f40e))
-
-# [1.3.0-alpha.2](https://github.com/frontegg/entitlements-client/compare/1.3.0-alpha.1...1.3.0-alpha.2) (2025-04-02)
-
-
-### Bug Fixes
-
-* **publish:** republish ([6a6be70](https://github.com/frontegg/entitlements-client/commit/6a6be704908c2d27482cea00f0ddf889ec47ab25))
-
-# [1.3.0-alpha.1](https://github.com/frontegg/entitlements-client/compare/1.2.0...1.3.0-alpha.1) (2025-04-02)
-
-
-### Features
-
-* **fga:** add fga policy query ([7ff9dd5](https://github.com/frontegg/entitlements-client/commit/7ff9dd56891a2b727f07d3b69857c01ea9377e14))
-* **log:** add subject and request context to logger ([f65e60a](https://github.com/frontegg/entitlements-client/commit/f65e60ad76b90580654e806326ba28fb4b67bf16))
+-   The justification type has been changed from enum to string in order to support multiple justification types
 
 # [1.2.0](https://github.com/frontegg/entitlements-client/compare/1.1.0...1.2.0) (2024-08-06)
 
-
 ### Features
 
-* **client configurations:** adding timeout and fallback configurations ([931bbad](https://github.com/frontegg/entitlements-client/commit/931bbadf2766fd869945b599668823ec682d6a6f))
-* **client configurations:** adding timeout and fallback configurations ([e3f4fd3](https://github.com/frontegg/entitlements-client/commit/e3f4fd35e16a3e72481abf0190243de75ceb176c))
-* **client configurations:** adding timeout and fallback configurations ([322117e](https://github.com/frontegg/entitlements-client/commit/322117e03df02180d3889cb705737df5c0090442))
-
+-   **client configurations:** adding timeout and fallback configurations ([931bbad](https://github.com/frontegg/entitlements-client/commit/931bbadf2766fd869945b599668823ec682d6a6f))
+-   **client configurations:** adding timeout and fallback configurations ([e3f4fd3](https://github.com/frontegg/entitlements-client/commit/e3f4fd35e16a3e72481abf0190243de75ceb176c))
+-   **client configurations:** adding timeout and fallback configurations ([322117e](https://github.com/frontegg/entitlements-client/commit/322117e03df02180d3889cb705737df5c0090442))
 
 ### Bug Fixes
 
-* **types:** allow sync function as fallback ([5b62111](https://github.com/frontegg/entitlements-client/commit/5b62111686bd9badab9be193e90557eaae70043e))
-* **types:** allow sync function as fallback ([0d3bfa0](https://github.com/frontegg/entitlements-client/commit/0d3bfa0c817d9ddbc96f8a2a358047d0a0eaf206))
-
-# [1.2.0-alpha.2](https://github.com/frontegg/entitlements-client/compare/1.2.0-alpha.1...1.2.0-alpha.2) (2024-08-06)
-
-
-### Bug Fixes
-
-* **types:** allow sync function as fallback ([5b62111](https://github.com/frontegg/entitlements-client/commit/5b62111686bd9badab9be193e90557eaae70043e))
-* **types:** allow sync function as fallback ([0d3bfa0](https://github.com/frontegg/entitlements-client/commit/0d3bfa0c817d9ddbc96f8a2a358047d0a0eaf206))
-
-# [1.2.0-alpha.1](https://github.com/frontegg/entitlements-client/compare/1.1.0...1.2.0-alpha.1) (2024-08-05)
-
-
-### Features
-
-* **client configurations:** adding timeout and fallback configurations ([e3f4fd3](https://github.com/frontegg/entitlements-client/commit/e3f4fd35e16a3e72481abf0190243de75ceb176c))
-* **client configurations:** adding timeout and fallback configurations ([322117e](https://github.com/frontegg/entitlements-client/commit/322117e03df02180d3889cb705737df5c0090442))
+-   **types:** allow sync function as fallback ([5b62111](https://github.com/frontegg/entitlements-client/commit/5b62111686bd9badab9be193e90557eaae70043e))
+-   **types:** allow sync function as fallback ([0d3bfa0](https://github.com/frontegg/entitlements-client/commit/0d3bfa0c817d9ddbc96f8a2a358047d0a0eaf206))
 
 # [1.1.0](https://github.com/frontegg/entitlements-client/compare/1.0.5...1.1.0) (2024-07-23)
 
-
 ### Features
 
-* **new_file:** Create text.txt ([11ea9b5](https://github.com/frontegg/entitlements-client/commit/11ea9b5c4f06e1cda33ba527083c9933f599f70c))
+-   **new_file:** Create text.txt ([11ea9b5](https://github.com/frontegg/entitlements-client/commit/11ea9b5c4f06e1cda33ba527083c9933f599f70c))
 
 ## [1.0.5](https://github.com/frontegg/entitlements-client/compare/1.0.4...1.0.5) (2024-07-23)
 
-
 ### Bug Fixes
 
-* **test:** Update CODEOWNERS ([f3e022f](https://github.com/frontegg/entitlements-client/commit/f3e022f02ff1974800db25e911713d2aa8a6f723))
+-   **test:** Update CODEOWNERS ([f3e022f](https://github.com/frontegg/entitlements-client/commit/f3e022f02ff1974800db25e911713d2aa8a6f723))
 
 ## [1.0.4](https://github.com/frontegg/entitlements-client/compare/1.0.3...1.0.4) (2024-07-23)
 
-
 ### Bug Fixes
 
-* **publish action:** add bot to pulish action ([3dce820](https://github.com/frontegg/entitlements-client/commit/3dce82092cdce520b5972f4e0057d5c40814c446))
+-   **publish action:** add bot to pulish action ([3dce820](https://github.com/frontegg/entitlements-client/commit/3dce82092cdce520b5972f4e0057d5c40814c446))
 
 ## [1.0.3](https://github.com/frontegg/entitlements-client/compare/1.0.2...1.0.3) (2024-06-16)
 
-
 ### Bug Fixes
 
-* **import-path:** fix relative import path ([9fe19c8](https://github.com/frontegg/entitlements-client/commit/9fe19c8c0b1011093dc9bbf3ea7538b79816e94b))
+-   **import-path:** fix relative import path ([9fe19c8](https://github.com/frontegg/entitlements-client/commit/9fe19c8c0b1011093dc9bbf3ea7538b79816e94b))
 
 ## [1.0.2](https://github.com/frontegg/entitlements-client/compare/1.0.1...1.0.2) (2024-06-02)
 
-
 ### Bug Fixes
 
-* fix SubjectContext required fields ([b18370e](https://github.com/frontegg/entitlements-client/commit/b18370e9fcaa2edf5d68dcaad8c9902c1ecd025c))
-* **SubjectContext:** update some fields to be optional ([96a12c6](https://github.com/frontegg/entitlements-client/commit/96a12c6aafd1c701ac2aec98cdf615c87766fc2e))
+-   fix SubjectContext required fields ([b18370e](https://github.com/frontegg/entitlements-client/commit/b18370e9fcaa2edf5d68dcaad8c9902c1ecd025c))
+-   **SubjectContext:** update some fields to be optional ([96a12c6](https://github.com/frontegg/entitlements-client/commit/96a12c6aafd1c701ac2aec98cdf615c87766fc2e))
 
 ## [1.0.1](https://github.com/frontegg/entitlements-client/compare/1.0.0...1.0.1) (2024-05-21)
 
-
 ### Bug Fixes
 
-* **update opa route:** update opa route ([59ca8f7](https://github.com/frontegg/entitlements-client/commit/59ca8f79e73de64d1749444f67775fc9edc7efd1))
-* **update opa route:** update opa route ([e820498](https://github.com/frontegg/entitlements-client/commit/e8204982312575610d97e763cb1cf8b9309edf91))
+-   **update opa route:** update opa route ([59ca8f7](https://github.com/frontegg/entitlements-client/commit/59ca8f79e73de64d1749444f67775fc9edc7efd1))
+-   **update opa route:** update opa route ([e820498](https://github.com/frontegg/entitlements-client/commit/e8204982312575610d97e763cb1cf8b9309edf91))
 
 # 1.0.0 (2024-05-12)
 
-
 ### Bug Fixes
 
-* **index.ts:** fixed wrong export of files and dirs ([cec9afe](https://github.com/frontegg/entitlements-client/commit/cec9afefc40c66d18d7b282bbd9331411f41a20b))
-* **package.json:** rename the module name ([4154503](https://github.com/frontegg/entitlements-client/commit/41545030de9eb716fd343f24e78bf23b1884a92b))
-
+-   **index.ts:** fixed wrong export of files and dirs ([cec9afe](https://github.com/frontegg/entitlements-client/commit/cec9afefc40c66d18d7b282bbd9331411f41a20b))
+-   **package.json:** rename the module name ([4154503](https://github.com/frontegg/entitlements-client/commit/41545030de9eb716fd343f24e78bf23b1884a92b))
 
 ### Features
 
-* [FR-15668] Introduce logging support and refactor basic structure to support better design ([8ba0cc0](https://github.com/frontegg/entitlements-client/commit/8ba0cc09e2cef112ab9360ce8678d0372d56b239))
+-   [FR-15668] Introduce logging support and refactor basic structure to support better design ([8ba0cc0](https://github.com/frontegg/entitlements-client/commit/8ba0cc09e2cef112ab9360ce8678d0372d56b239))

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		}
 	},
 	"dependencies": {
-		"@authzed/authzed-node": "^1.6.1",
+		"@authzed/authzed-node": "1.6.1",
 		"lru-cache": "^10.4.3"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@authzed/authzed-node@^1.6.1":
+"@authzed/authzed-node@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-1.6.1.tgz#b7e4930bd6ccf4499092a54e094f7104a80fc628"
   integrity sha512-Rj3rMtWOjo3igxY/2fpPrIedCTfDq3e+weykuxNBzV/y6azBCoXp8SzpjCEJXVcWyBD8bu/EKY3cye3kOLsKpQ==


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Changelog cleanup**
> 
> - Rewrites `docs/CHANGELOG.md` to a concise, normalized format for released versions (e.g., `2.0.0`, `1.2.0`), removing alpha/noise and deduplications.
> 
> **Dependencies**
> 
> - Pins `@authzed/authzed-node` from `^1.6.1` to `1.6.1` in `package.json`; updates `yarn.lock` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 626928d0c7da9bef97ec14bb859f2efea45a8c93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->